### PR TITLE
Gradleプロジェクトインポート時のエラー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.project
 /.classpath
 /.gradle/
+/.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -75,40 +75,9 @@ def exportDataTargetTables=[] as String[]
 def exportXmlWithRowDumpTables=[] as String[]
 def font="${font}"
 
-// add Repository
-repositories {
-	mavenLocal()
-	mavenCentral()
-}
-
 configurations {
 	all*.exclude group: "log4j", module: "log4j"
 	all*.exclude group: "org.projectlombok", module: "lombok"
-}
-
-// search dependencies by http://mvnrepository.com/
-dependencies {
-	File libFile=file('lib');
-	if (libFile.exists()&&libFile.list()!=null&&libFile.list().length>0) {
-		implementation fileTree(dir: 'extlib', include: '*.jar')
-		implementation fileTree(dir: 'lib', include: '*.jar')
-	} else {
-		implementation fileTree(dir: 'extlib', include: '*.jar')
-		implementation 'org.codehaus.janino:janino:2.7.8'
-		//DB
-		if ("${jdbc_driver}"!="") {
-			implementation "${jdbc_driver}"
-		}
-		implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
-		
-		//sqlapp
-		[
-			'sqlapp-core',
-			'sqlapp-command',
-			'sqlapp-gradle-plugin',
-			"sqlapp-core-${db}"
-		].each { name -> implementation "com.sqlapp:${name}:+" }
-	}
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,6 @@ plugins {
 	id 'java'
 	id 'java-library'
 }
-import java.io.File
-import java.util.function.Predicate
-
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.Optional
 
 group = 'com.sqlapp'
 //archivesBaseName = 'sample-db'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
 	repositories {
 		mavenLocal()
 		mavenCentral()
-		maven { url 'https://version99.qos.ch' }
 	}
 
 	dependencies {
@@ -80,7 +79,6 @@ def font="${font}"
 repositories {
 	mavenLocal()
 	mavenCentral()
-	maven { url 'http://version99.qos.ch' }
 }
 
 configurations {
@@ -97,7 +95,6 @@ dependencies {
 	} else {
 		implementation fileTree(dir: 'extlib', include: '*.jar')
 		implementation 'org.codehaus.janino:janino:2.7.8'
-		implementation 'commons-logging:commons-logging:99-empty'
 		//DB
 		if ("${jdbc_driver}"!="") {
 			implementation "${jdbc_driver}"


### PR DESCRIPTION
以下の修正の確認をこちらのサンプルプロジェクトで行う際、いくつかエラーが発生しましたので解消しました。

* https://github.com/satotatsu/sqlapp/pull/1

## エラー内容

Gradleのリフレッシュ時に発生します。

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':compileClasspath'.
Using insecure protocols with repositories, without explicit opt-in, is unsupported. Switch Maven repository 'maven(http://version99.qos.ch)' to redirect to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/7.4.1/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details. 

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
```

version99.qos.chにhttpでアクセスしているため発生していました。

## 修正方法

出力されているメッセージ通りにhttpsに変更する修正も考えましたが、version99.qos.chはすでに廃止されているようです。

https://mailman.qos.ch/pipermail/announce/2022/000180.html

`commons-logging:commons-logging:99-empty` を使うため使用していたようですが、そもそもビルド用のスクリプトしかないためdependenciesブロックが不要に思いました。
またビルド用のスクリプトで使用しているライブラリはsqlappしかないため、ビルド用スクリプトのリポジトリ設定にversion99.qos.ch追加は不要に思いました。
不要な設定でエラーになっていると考えたため、それらを削除しました。

またそれ以外に細かいリファクタリングなども行っています。コミットメッセージを参考にしてください。



